### PR TITLE
fix: remove the particulars of claim document (CMC-1322) 2/3

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFiles.java
@@ -18,19 +18,19 @@ public class ServedDocumentFiles {
     private List<Element<DocumentWithRegex>> other;
     private List<Element<Document>> medicalReports;
     private List<Element<DocumentWithRegex>> scheduleOfLoss;
-    private List<Element<Document>> particularsOfClaimFile;
+    private List<Element<Document>> particularsOfClaimDocument;
     private String particularsOfClaimText;
     private List<Element<DocumentWithRegex>> certificateOfSuitability;
 
     @JsonIgnore
     public List<String> getErrors() {
         List<String> errors = new ArrayList<>();
-        if (ofNullable(particularsOfClaimFile).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
+        if (ofNullable(particularsOfClaimDocument).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
             errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
                            + "of claim text in the field provided. You cannot do both.");
         }
 
-        if (ofNullable(particularsOfClaimFile).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
+        if (ofNullable(particularsOfClaimDocument).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
             errors.add("You must add Particulars of claim details");
         }
         return errors;

--- a/src/main/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFiles.java
@@ -18,18 +18,19 @@ public class ServedDocumentFiles {
     private List<Element<DocumentWithRegex>> other;
     private List<Element<Document>> medicalReports;
     private List<Element<DocumentWithRegex>> scheduleOfLoss;
-    private Document particularsOfClaimDocument;
+    private List<Element<Document>> particularsOfClaimFile;
     private String particularsOfClaimText;
     private List<Element<DocumentWithRegex>> certificateOfSuitability;
 
     @JsonIgnore
     public List<String> getErrors() {
         List<String> errors = new ArrayList<>();
-        if (ofNullable(particularsOfClaimDocument).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
-            errors.add("More than one Particulars of claim details added");
+        if (ofNullable(particularsOfClaimFile).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
+            errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
+                           + "of claim text in the field provided. You cannot do both.");
         }
 
-        if (ofNullable(particularsOfClaimDocument).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
+        if (ofNullable(particularsOfClaimFile).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
             errors.add("You must add Particulars of claim details");
         }
         return errors;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFilesTest.java
@@ -15,7 +15,7 @@ class ServedDocumentFilesTest {
         @Test
         void shouldReturnEmptyList_WhenOnlyDocument() {
             ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
-                .particularsOfClaimFile(wrapElements(Document.builder().build()))
+                .particularsOfClaimDocument(wrapElements(Document.builder().build()))
                 .build();
 
             assertThat(servedDocumentFiles.getErrors()).isEmpty();
@@ -40,7 +40,7 @@ class ServedDocumentFilesTest {
         @Test
         void shouldReturnMoreThanOneError_WhenBothParticularsOfClaimFieldsAreNotNull() {
             ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
-                .particularsOfClaimFile(wrapElements(Document.builder().build()))
+                .particularsOfClaimDocument(wrapElements(Document.builder().build()))
                 .particularsOfClaimText("Some string")
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/model/ServedDocumentFilesTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.unspec.model.documents.Document;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.unspec.utils.ElementUtils.wrapElements;
 
 class ServedDocumentFilesTest {
 
@@ -14,7 +15,7 @@ class ServedDocumentFilesTest {
         @Test
         void shouldReturnEmptyList_WhenOnlyDocument() {
             ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
-                .particularsOfClaimDocument(Document.builder().build())
+                .particularsOfClaimFile(wrapElements(Document.builder().build()))
                 .build();
 
             assertThat(servedDocumentFiles.getErrors()).isEmpty();
@@ -39,12 +40,13 @@ class ServedDocumentFilesTest {
         @Test
         void shouldReturnMoreThanOneError_WhenBothParticularsOfClaimFieldsAreNotNull() {
             ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
-                .particularsOfClaimDocument(Document.builder().build())
+                .particularsOfClaimFile(wrapElements(Document.builder().build()))
                 .particularsOfClaimText("Some string")
                 .build();
 
             assertThat(servedDocumentFiles.getErrors())
-                .containsOnly("More than one Particulars of claim details added");
+                .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
+                                  + "of claim text in the field provided. You cannot do both.");
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1322


### Change description ###
* Changed particularsOfClaimFile from a document to a collection of documents
* Changed error for submitting particulars of claim document and text at the same time
* Changed the assertion for the error 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
