### PR TITLE
fix: CVE-2021-22112 Bump spring-security-core from 5.4.2 to 5.4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,6 +299,8 @@ dependencies {
 
   implementation group: 'org.springframework.security', name: 'spring-security-web'
   implementation group: 'org.springframework.security', name: 'spring-security-config'
+  // CVE-2021-22112 - Privilege Escalation
+  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.4.6'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
   implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.8.1'


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a


### Change description ###

Bump spring-security-core from 5.4.2 to 5.4.6

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
