### PR TITLE
fix:  confirmation screen for resubmit claim event (N/A)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/user/ResubmitClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/user/ResubmitClaimCallbackHandler.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.SUBMITTED;
@@ -61,9 +62,9 @@ public class ResubmitClaimCallbackHandler extends CallbackHandler {
     private SubmittedCallbackResponse buildConfirmation(CallbackParams callbackParams) {
         return SubmittedCallbackResponse.builder()
             .confirmationHeader("# Claim pending")
-            .confirmationBody("## What happens next %n "
-                                  + "You claim will be processed. Wait for us to contact you."
-                                  + exitSurveyContentService.applicantSurvey()
+            .confirmationBody(
+                format("## What happens next %n%nYou claim will be processed. Wait for us to contact you.")
+                    + exitSurveyContentService.applicantSurvey()
             )
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.unspec.model.CaseData;
 import uk.gov.hmcts.reform.unspec.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.unspec.service.ExitSurveyContentService;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.SUBMITTED;
@@ -72,9 +73,9 @@ class ResubmitClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
             assertThat(response).usingRecursiveComparison().isEqualTo(
                 SubmittedCallbackResponse.builder()
                     .confirmationHeader("# Claim pending")
-                    .confirmationBody("## What happens next %n "
-                                          + "You claim will be processed. Wait for us to contact you."
-                                          + exitSurveyContentService.applicantSurvey()
+                    .confirmationBody(
+                        format("## What happens next %n%nYou claim will be processed. Wait for us to contact you.")
+                            + exitSurveyContentService.applicantSurvey()
                     )
                     .build());
         }


### PR DESCRIPTION
### Change description ###
Fix confirmation screen for resubmit claim event


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

<img width="726" alt="Screenshot 2021-05-10 at 13 09 01" src="https://user-images.githubusercontent.com/12894151/117668409-cf401f80-b19d-11eb-835c-0e7faa922fa7.png">
